### PR TITLE
Add docker 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
 jobs:
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . -t spech66/lifelogspd -t spech66/lifelogspd:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.16-alpine
+
+ADD . /app
+WORKDIR /app
+RUN go build
+
+CMD ./lifelogspd -config /app/config.json

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ This daemon is intend for use in a local network. For securing the access use a 
 * **Endurance workout:** :heavy_check_mark:
 * **Endurance workout chart:** :heavy_check_mark:
 
+## Selfhost with docker
+
+```
+  $ git clone https://github.com/spech66/lifelogspd
+  $ cd lifelogspd 
+  $ docker run -p 8066:8066 `pwd`/data:/app/data `pwd`/example.config.json:/app/config.json
+```
+
 ## Screenshots
 
 ![Start](https://raw.githubusercontent.com/spech66/lifelogspd/master/_screenshots/s_001_start.png "Start")
@@ -52,6 +60,7 @@ cd %GOPATH%\src\github.com\spech66\lifelogspd
 go build
 lifelogspd.exe -config example.config.json
 ```
+
 
 ## nginx reverse proxy with basic auth
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This daemon is intend for use in a local network. For securing the access use a 
 ```
   $ git clone https://github.com/spech66/lifelogspd
   $ cd lifelogspd 
-  $ docker run -p 8066:8066 `pwd`/data:/app/data `pwd`/example.config.json:/app/config.json
+  $ docker build . -t lifelogspd
+  $ docker run -p 8066:8066 -v `pwd`/data:/app/data `pwd`/example.config.json:/app/config.json lifelogspd
 ```
 
 ## Screenshots


### PR DESCRIPTION
The easiest and most common way to deploy self-hosted services - the docker.
Added docker file for this project. 

I would also recommend creating an image and pushing it to [doc](https://hub.docker.com/) 
So users could use this project without fetching sources  